### PR TITLE
Adds support for bridged networking.

### DIFF
--- a/vido
+++ b/vido
@@ -200,6 +200,9 @@ sp_kvm = parser.add_argument_group('KVM-only options')
 sp_kvm.add_argument(
     '--net', action='store_true',
     help='Configure the network (unnecessary with userns)')
+sp_kvm.add_argument(
+    '--bridge', default=[], nargs='*',
+    help='Bridges to use for virtual NICs')
 # qemu needs this to catch crashes (unnecessary with uml)
 sp_kvm.add_argument(
     '--watchdog', action='store_true',
@@ -267,8 +270,10 @@ if args.watchdog and args.virt != 'kvm':
     fatal('--watchdog is not supported with {}'.format(args.virt))
 if args.qemu_9p_workaround and args.virt != 'kvm':
     fatal('--qemu-9p-workaround is not supported with {}'.format(args.virt))
-if args.net and args.virt != 'kvm':
-    fatal('--net is not supported with {}'.format(args.virt))
+if (args.net or args.bridge) and args.virt != 'kvm':
+    fatal('--net and --bridge not supported with {}'.format(args.virt))
+if args.net and args.bridge:
+    fatal('--net and --bridge cannot be active at the same time')
 if args.run_as and args.virt not in 'kvm uml'.split():
     fatal('--run-as is not supported with {}'.format(args.virt))
 if args.gdb and args.virt not in 'kvm uml'.split():
@@ -348,6 +353,12 @@ if args.virt == 'kvm':
         # Not passing dns, sharing the host's resolv.conf
         # Suggest a port-forward for the local resolver case
         conf.net = dict(host='10.0.2.15/24', router='10.0.2.2')
+    elif args.bridge:
+        for i, bridge in enumerate(args.bridge):
+            qcmd += ['-net', 'nic,vlan=%d' % i, '-net',
+                     'bridge,vlan=%d,br=%s' % (i, bridge)]
+        conf.bridge = len(args.bridge)
+
 
     if args.watchdog:
         qcmd += ['-watchdog', 'ib700', '-watchdog-action', 'poweroff']
@@ -452,4 +463,3 @@ else:
         if not exitstr:
             fatal('virt-stub crashed')
         sys.exit(int(exitstr))
-

--- a/virt-stub
+++ b/virt-stub
@@ -192,6 +192,9 @@ if hasattr(conf, 'net'):
     subprocess.check_call(
         'ip route add default via'.split() + [conf.net.router]
         + 'dev eth0'.split())
+elif hasattr(conf, 'bridge'):
+    for i in range(conf.bridge):
+        subprocess.check_call(['/usr/bin/dhcpcd', '--noarp', '-b', 'eth%d' % i])
 
 for i, disk in enumerate(conf.disks):
     env['VIDO_DISK{}'.format(i)] = disk
@@ -201,4 +204,3 @@ exit_status_file.write('%d' % rcode)
 exit_status_file.close()
 if conf.virt != 'userns':
     subprocess.check_call('/sbin/poweroff -f'.split())
-


### PR DESCRIPTION
This PR adds the ability to create multiple guest interfaces using a bridge interface on the host. Basically, on the host, you do something like this:

```bash
# First create a bridge.
$ sudo brctl addbr bridge0
# Then connect it to the host's ethernet interface.
$ sudo brctl addif bridge0 eth0
```

Then, you can launch the kernel vm with vido:

```bash
$ vido --kvm --kernel arch/x86_64/boot/bzImage --bridge bridge0 -- sh
```

In the stub script, a dhcp client server will be launched for each interface created.

This also supports creating multiple guest interfaces that either share the same bridge or use different bridges:

```bash
$ vido --kvm --kernel arch/x86_64/boot/bzImage --bridge bridge0 bridge0 -- sh
```

The resulting VM has eth0 and eth1 which behave as completely independent NICs.

This is implemented using Qemu's [bridge helper](https://wiki.archlinux.org/index.php/QEMU#Bridged_networking_using_qemu-bridge-helper), which will create the required TAP device and add it to your bridge. You may need to edit `/etc/qemu/bridge.conf` to include the bridge device you created, as described in the link.

I figured you might want to at least see this functionality, even if you don't end up merging it. It's very important for my use case, but I can always keep using my fork!