### PR TITLE
Support running different installed kernels

### DIFF
--- a/vido
+++ b/vido
@@ -179,6 +179,8 @@ sp_kernel = parser.add_argument_group('Kernel options')
 sp_kernel.add_argument(
     '--kernel', metavar='KERNEL', help='Kernel executable')
 sp_kernel.add_argument(
+    '--kernel-version', metavar='VERSION', help='Installed kernel version')
+sp_kernel.add_argument(
     '--mem', help='Memory limit (use KMG suffixes)')
 sp_kernel.add_argument(
     '--gdb', action='store_true', help='Run the kernel in a debugger')
@@ -331,11 +333,16 @@ if args.virt == 'kvm':
     open_ipc()
 
     if args.kernel is None:
+        if args.kernel_version:
+            kernel_ver = args.kernel_version
+        else:
+            kernel_ver = os.uname().release
+
         # Those may not work out of the box, need 9p+virtio built-in
         # Building a custom initramfs would work around that
-        qcmd += ['-kernel', '/boot/vmlinuz-' + os.uname().release]
+        qcmd += ['-kernel', '/boot/vmlinuz-' + kernel_ver]
         add_9p_mods = True
-        modbase = '/lib/modules/' + os.uname().release + '/'
+        modbase = '/lib/modules/' + kernel_ver + '/'
     else:
         qcmd += ['-kernel', args.kernel]
         add_9p_mods = False


### PR DESCRIPTION
This patch adds a command-line option to use a different kernel version
than the one currently running (when there are other versions
installed).