### PR TITLE
Add '-cpu host' to QEMU flags in KVM mode

### DIFF
--- a/vido
+++ b/vido
@@ -310,6 +310,7 @@ if args.virt == 'kvm':
 
     qcmd = [
         qemu,
+        '-cpu', 'host',
         '-m', args.mem, '-enable-kvm', '-nodefaults',
         '-serial', 'stdio', '-nographic',
         '-fsdev', 'local,id=root,path=/,security_model=none',


### PR DESCRIPTION
In KVM mode we always run on the same CPU, so it makes sense to expose
host CPU features to the VM.