### PR TITLE
kvm: Use kvm_guest.config in new location

### DIFF
--- a/kvm.config
+++ b/kvm.config
@@ -1,5 +1,5 @@
 # Applies on top of arch/x86/configs/kvm_guest.config
-# source/scripts/kconfig/merge_config.sh -n source/arch/x86/configs/kvm_guest.config vido/kvm.config
+# source/scripts/kconfig/merge_config.sh -n kernel/configs/kvm_guest.config vido/kvm.config
 
 CONFIG_64BIT=y
 CONFIG_PRINTK=y


### PR DESCRIPTION
Since bd6c92221d2081045cbc5f13c8c1de77e3ff569e Linux provides this configuration in another place. This change reflects that change in that the new location is used.